### PR TITLE
Release 0.1.1

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - 2022-05-18
+
+### Added
+
+- Added documentation on warning for `ENFORCE_CLUSTER_GROUP_TOP_LEVEL`
+- Added `netutils` package
+- fixed a bug with `mac_address` being None causing an orm query call exception
+
+### Changed
+
+### Removed
+
 ## [0.1.0] - 2022-05-17
 
 - Initial release of Nautobot SSoT vSphere Plugin

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nautobot-ssot-vsphere"
-version = "0.1.0"
+version = "0.1.1"
 description = "Nautobot SSoT vSphere"
 authors = ["h4ndzdatm0ld <hugotinoco@icloud.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
## [0.1.1] - 2022-05-18

### Added

- Added documentation on warning for `ENFORCE_CLUSTER_GROUP_TOP_LEVEL`
- Added `netutils` package
- fixed a bug with `mac_address` being None causing an orm query call exception

### Changed

### Removed