### PR TITLE
Release v0.1.3

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.3] - 2022-08-12
+## [0.1.3] - 2022-08-13
 
 ### Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nautobot-ssot-vsphere"
-version = "0.1.2"
+version = "0.1.3"
 description = "Nautobot SSoT vSphere"
 authors = ["h4ndzdatm0ld <hugotinoco@icloud.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
## [0.1.3] - 2022-08-13

### Added

- Added default (configurable) setting to always drop link-local addresses from IPv6 assigned interfaces from vSphere
- Added logging to interface addresses dropped

### Changed

- Bumped Django to 3.2.15 due to security fix

### Removed

