### PR TITLE
docs/release

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.1.4] - 2022-11-06
 
 ### Added
 
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Exception raised when a vm doesn't have any disks.
 - Filtering logic was missing to aggregate VM's from nautobot, if defined in job args
+- Documentation pointed to invalid configuration values
 
 ### Removed
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,6 +1,10 @@
 # Overview of Nautobot SSoT vSphere
 
+A plugin for [Nautobot](https://github.com/nautobot/nautobot) that leverages the SSoT plugin to create Virtual Machines, VMInterfaces, IPAddresses, Clusters, and Cluster Groups from VMWare vSphere.
+
 ## Configuration Settings
+
+The following options are user configurable to _attempt_ to provide the user with a better synchronization experience, depending on what the environment's deployment looks like. All of the options below have default values set and you most likely for the most common deployment of vSphere / DataCenters / Clusters.
 
 `VSPHERE_TYPE`
 
@@ -10,14 +14,26 @@
 
 - `Diffsync` has a concept of `Top Level`. This application defaults to the `ClusterGroup` as Top Level, which translates to a vSphere DataCenter. This can be changed to have a Cluster in vSphere be the Top Level and ignore DataCenters.
 
-`VSPHERE_VM_STATUS_MAP, VSPHERE_IP_STATUS_MAP, VSPHERE_VM_INTERFACE_MAP`
+`DEFAULT_VM_STATUS_MAP, DEFAULT_IP_STATUS_MAP, VSPHERE_VM_INTERFACE_MAP`
 
 - These are dictionary (maps) that translate the vSphere value to something Nautobot can understand. You must be sure that the values provided are valid before manipulating these maps.
 
-```bash
-- `VSPHERE_VM_STATUS_MAP` Defaults to {"POWERED_OFF": "Offline", "POWERED_ON": "Active", "SUSPENDED": "Suspended"}
-- `VSPHERE_IP_STATUS_MAP` Defaults to {"PREFERRED": "Active", "UNKNOWN": "Reserved"}
-- `VSPHERE_VM_INTERFACE_MAP` Defaults to {"NOT_CONNECTED": False, "CONNECTED": True}
+- `DEFAULT_VM_STATUS_MAP` Defaults to
+
+```json
+{ "POWERED_OFF": "Offline", "POWERED_ON": "Active", "SUSPENDED": "Suspended" }
+```
+
+- `DEFAULT_IP_STATUS_MAP` Defaults to
+
+```json
+{ "PREFERRED": "Active", "UNKNOWN": "Reserved" }
+```
+
+- `VSPHERE_VM_INTERFACE_MAP` Defaults to
+
+```json
+{"NOT_CONNECTED": False, "CONNECTED": True}
 ```
 
 `PRIMARY_IP_SORT_BY`
@@ -31,3 +47,11 @@
 `DEFAULT_IGNORE_LINK_LOCAL`
 
 - Defaults to `True` and drops any link-local address found on a vSphere vm that has an IPv6 address assigned.
+
+`DEFAULT_IP_STATUS_MAP`
+
+- This allows you to change what the `Status` of an interface maps to from vSphere -> Nautobot. Defaults to the following:
+
+```json
+{ "PREFERRED": "Active", "UNKNOWN": "Reserved" }
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nautobot-ssot-vsphere"
-version = "0.1.3"
+version = "0.1.4"
 description = "Nautobot SSoT vSphere"
 authors = ["h4ndzdatm0ld <hugotinoco@icloud.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
## [0.1.4] - 2022-11-06

### Added

- CodeQL Action
- `SUSPENDED` state as a default to `Offline`

### Changed

- Bumped version of Poetry Action
- Added a Nautobot version to the testing matrix in CI
- Bumped `oauthlib` to 3.2.1
- Unpinned `responses` testing library

### Fixed

- Exception raised when a vm doesn't have any disks.
- Filtering logic was missing to aggregate VM's from nautobot, if defined in job args
- Documentation pointed to invalid configuration values

### Removed