### PR TITLE
Docker Compose no longer allows duplicate `<<` entries.

### DIFF
--- a/development/docker-compose.base.yml
+++ b/development/docker-compose.base.yml
@@ -21,8 +21,9 @@ services:
         condition: "service_started"
       db:
         condition: "service_healthy"
-    <<: *nautobot-build
-    <<: *nautobot-base
+    <<:
+      - *nautobot-build
+      - *nautobot-base
   worker:
     entrypoint:
       - "sh"


### PR DESCRIPTION
Repeated anchors are not allowed in YAML, the values should be a list. See docker/compose#10411